### PR TITLE
Multiple fixes for use in other repositories

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -108,15 +108,11 @@ runs:
       id: generate-badge
       shell: bash
       run: |
-        # Escape special characters in inputs
-        LABEL="${{ inputs.label }}"
-        STATUS="${{ inputs.status }}"
-
         # Build base command
         CMD=(
           php bin/badge
-          "$LABEL"
-          "$STATUS"
+          "${{ inputs.label }}"
+          "${{ inputs.status }}"
           "${{ inputs.path }}"
         )
 

--- a/action.yml
+++ b/action.yml
@@ -86,6 +86,7 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
+        cd ${{ github.action_path }}
         composer install --no-dev --no-progress --no-interaction --optimize-autoloader
         if [ $? -ne 0 ]; then
           echo "::error::Failed to install dependencies"
@@ -110,7 +111,7 @@ runs:
       run: |
         # Build base command
         CMD=(
-          php bin/badge
+          php ${{ github.action_path }}/bin/badge
           "${{ inputs.label }}"
           "${{ inputs.status }}"
           "${{ inputs.path }}"

--- a/action.yml
+++ b/action.yml
@@ -111,8 +111,6 @@ runs:
         # Escape special characters in inputs
         LABEL="${{ inputs.label }}"
         STATUS="${{ inputs.status }}"
-        LABEL=$(echo "$LABEL" | sed 's/[^a-zA-Z0-9-]/_/g')
-        STATUS=$(echo "$STATUS" | sed 's/%/%25/g' | sed 's/ /%20/g' | sed 's/[^a-zA-Z0-9%.-]/_/g')
 
         # Build base command
         CMD=(

--- a/src/Services/ShieldsIoUrlBuilder.php
+++ b/src/Services/ShieldsIoUrlBuilder.php
@@ -29,7 +29,7 @@ class ShieldsIoUrlBuilder implements UrlBuilderInterface
     {
         $encodedLabel = $this->encodeParameter($label);
         $encodedStatus = $this->encodeParameter($status);
-        $color = $params['color'] ?? 'blue';
+        $color = $this->encodeParameter($params['color'] ?? 'blue');
 
         $url = "{$this->baseUrl}/{$encodedLabel}-{$encodedStatus}-{$color}";
 

--- a/src/Services/ShieldsIoUrlBuilder.php
+++ b/src/Services/ShieldsIoUrlBuilder.php
@@ -52,8 +52,8 @@ class ShieldsIoUrlBuilder implements UrlBuilderInterface
     {
         // First, handle special characters that need custom encoding
         $str = str_replace(
-            ['%', '_', '-'],
-            ['%25', '__', '--'],
+            ['_', '-'],
+            ['__', '--'],
             $str
         );
 


### PR DESCRIPTION
This PR:
1. removes a fair bit of duplicated url encoding for "%" signs
    a. this lead to quite a lot of "%25"'s being left in badges
2. uses the correct path when running `composer install` in other repositories
    b. this meant that the action failed consistently when run from other repos